### PR TITLE
升级 fis3-parser-typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yog2",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Front End Integrated Solution for node express.",
   "main": "yog2.js",
   "bin": {
@@ -30,7 +30,7 @@
     "fis3": "3.4.33",
     "fis3-hook-commonjs": "0.1.26",
     "fis3-hook-node_modules": "2.2.8",
-    "fis3-parser-typescript": "1.1.4",
+    "fis3-parser-typescript": "1.2.2",
     "fis3-preprocessor-js-require-css": "0.1.1",
     "fis3-preprocessor-js-require-file": "0.1.3",
     "liftoff": "2.3.0",


### PR DESCRIPTION
目前版本的 fis3-parser-typescript(v1.1.4) 依赖的 typescript(v2.1.6) 版本较低， 编译最新版的 vue（v2.5.16）里的   ts 文件会报错。